### PR TITLE
Fix/docker images setting

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -50,10 +50,7 @@ dockerImage = 'mojaloop/central-ledger:latest'
 # Ignored when `mode != "docker"`
 # Override by setting `dockerImages` env variable
 ##
-dockerImages = [
-  "mojaloop/ml-api-adapter:latest",
-  "mojaloop/central-ledger:latest"
-]
+dockerImages = []
 
 
 ##

--- a/config.toml
+++ b/config.toml
@@ -101,7 +101,8 @@ excludeList = [
   "buffercursor@0.0.12;No license on github or npm", # has no license on github or npm
   "cycle@1.0.3;Listed as Public-Domain on npm, but no License file in github",
   "spdx-exceptions@2.2.0;Requires attribution",
-  "xmldom@0.1.27;Allows either MIT or LGPL License"
+  "xmldom@0.1.19;Allows either MIT or LGPL License",
+  "xmldom@0.1.27;Allows either MIT or LGPL License",
 ]
 
 ##

--- a/scripts/_run_docker.sh
+++ b/scripts/_run_docker.sh
@@ -95,8 +95,10 @@ function processDockerImage() {
     exit ${dockerCreateResult}
   fi
 
-  # copy out node_modules
+  # copy out node_modules - look in project root as well as .<project>/src and /src
   docker cp $containerName:/opt/$containerName/node_modules /tmp/$containerName/node_modules
+  docker cp $containerName:/opt/$containerName/src/node_modules /tmp/$containerName/node_modules
+  docker cp $containerName:/src/node_modules /tmp/$containerName/node_modules
 
   # run the license scan
   listLicenses ${containerName} /tmp/$containerName/node_modules

--- a/scripts/_run_docker.sh
+++ b/scripts/_run_docker.sh
@@ -96,9 +96,19 @@ function processDockerImage() {
   fi
 
   # copy out node_modules - look in project root as well as .<project>/src and /src
-  docker cp $containerName:/opt/$containerName/node_modules /tmp/$containerName/node_modules
-  docker cp $containerName:/opt/$containerName/src/node_modules /tmp/$containerName/node_modules
-  docker cp $containerName:/src/node_modules /tmp/$containerName/node_modules
+  docker cp $containerName:/opt/$containerName/node_modules /tmp/$containerName/ > /dev/null 2>&1 
+  docker cp $containerName:/opt/$containerName/src/node_modules /tmp/$containerName/ > /dev/null 2>&1 
+  docker cp $containerName:/src/node_modules /tmp/$containerName/ > /dev/null 2>&1 
+
+  # check that the copy worked - this seems especially brittle
+  if [ "$(ls -A /tmp/${containerName}/node_modules)" ]; then
+    logSubStep "Copied node_modules successfully"
+  else
+    logErr "Fatal Error. Failed to copy node modules out of docker image: ${stepDockerImage}. Aborting"
+    exit 1
+  fi
+
+  # exit 1
 
   # run the license scan
   listLicenses ${containerName} /tmp/$containerName/node_modules

--- a/scripts/_run_docker.sh
+++ b/scripts/_run_docker.sh
@@ -108,11 +108,9 @@ function processDockerImage() {
     exit 1
   fi
 
-  # exit 1
-
   # run the license scan
-  listLicenses ${containerName} /tmp/$containerName/node_modules
-  checkLicenses ${containerName} /tmp/$containerName/node_modules
+  listLicenses ${containerName} /tmp/$containerName
+  checkLicenses ${containerName} /tmp/$containerName
   result=$?
 
   #cleanup

--- a/scripts/_run_docker.sh
+++ b/scripts/_run_docker.sh
@@ -78,11 +78,10 @@ function processDockerImage() {
   docker rm -f $containerName  > /dev/null 2>&1 || logSubStep 'Container already stopped'
   docker pull $stepDockerImage
 
-  # Make sure the container exists, and we can pull it
+  # Check if the image exists, and we can pull it
   dockerPullResult=$?
   if [ ${dockerPullResult} -ne 0 ]; then
-    logErr "failed to pull docker image: ${stepDockerImage}. Aborting."
-    exit ${dockerPullResult}
+    logWarn "failed to pull docker image: ${stepDockerImage}. This may not be fatal"
   fi
 
   logSubStep "Creating $containerName from $stepDockerImage"
@@ -90,15 +89,14 @@ function processDockerImage() {
   # create a non-running container
   docker create --name $containerName $stepDockerImage
 
-  # copy out node_modules
-  # Hacky workaround for inconsistent naming of mojaloop simulator: TODO: remote this once ticket is closed
-  # Open Ticket: https://github.com/mojaloop/project/issues/929
-  if [ "$containerName" == "simulator" ]; then
-    logWarn "mojaloop/simulator file path is inconsistent - using temporary hacky workaround to get node_modules"
-    docker cp $containerName:/opt/simulators/node_modules /tmp/$containerName/node_modules
-  else 
-    docker cp $containerName:/opt/$containerName/node_modules /tmp/$containerName/node_modules
+  dockerCreateResult=$?
+  if [ ${dockerCreateResult} -ne 0 ]; then
+    logErr "failed to create docker image: ${stepDockerImage}. Aborting"
+    exit ${dockerCreateResult}
   fi
+
+  # copy out node_modules
+  docker cp $containerName:/opt/$containerName/node_modules /tmp/$containerName/node_modules
 
   # run the license scan
   listLicenses ${containerName} /tmp/$containerName/node_modules


### PR DESCRIPTION
By default, we were setting the newer `dockerImages` variable in `config.toml`. This was causing problems as the existing usage of the license-scanner sets the `dockerImage` variable (which is now deprecated), which was getting overriden by the default config.

See the following logs from [CI/CD](https://circleci.com/gh/mojaloop/mojaloop-simulator/166):
```
[WARN] Both 'dockerImage' and 'dockerImages' found. Ignoring deprecated 'dockerImage' setting.
```

I also included some other fixes to the way this tool was running in docker mode, which will make it more reliable for new repos.