### PR TITLE
Feature/1031 remove xmldom

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -97,9 +97,7 @@ excludeList = [
   "taffydb@2.6.2;Contains MIT license on github, but not listed in package.json",
   "buffercursor@0.0.12;No license on github or npm", # has no license on github or npm
   "cycle@1.0.3;Listed as Public-Domain on npm, but no License file in github",
-  "spdx-exceptions@2.2.0;Requires attribution",
-  "xmldom@0.1.19;Allows either MIT or LGPL License",
-  "xmldom@0.1.27;Allows either MIT or LGPL License",
+  "spdx-exceptions@2.2.0;Requires attribution"
 ]
 
 ##

--- a/config.toml
+++ b/config.toml
@@ -101,7 +101,8 @@ excludeList = [
   "buffercursor@0.0.12;No license on github or npm", # has no license on github or npm
   "cycle@1.0.3;Listed as Public-Domain on npm, but no License file in github",
   "spdx-exceptions@2.2.0;Requires attribution",
-  "xmldom@0.1.27;Allows either MIT or LGPL License"
+  "xmldom@0.1.19;Allows either MIT or LGPL License",
+  "xmldom@0.1.27;Allows either MIT or LGPL License",
 ]
 
 ##


### PR DESCRIPTION
### NOTE: Wait until new 8.6.0 helm release without `mock-pathfinder` to merge this PR

Removes xmldom from the license-scanner whitelist. This means any scans with xmldom will fail.

