### PR TITLE
omit processDockerImage on finance portal UI

### DIFF
--- a/scripts/_run_docker.sh
+++ b/scripts/_run_docker.sh
@@ -129,7 +129,9 @@ dockerImages=`echo ${dockerImages} | awk '{gsub(/[;]/," ");print}'`
 # iterate through docker images
 for OUTPUT in ${dockerImages}
 do
-  processDockerImage ${OUTPUT}
+  if [ ${OUTPUT} -ne "finance-portal-ui" ]; then
+    processDockerImage ${OUTPUT}
+  fi
 done
 
 exit 0

--- a/scripts/_run_docker.sh
+++ b/scripts/_run_docker.sh
@@ -131,6 +131,8 @@ for OUTPUT in ${dockerImages}
 do
   if [ ${OUTPUT} -ne "finance-portal-ui" ]; then
     processDockerImage ${OUTPUT}
+  else
+    logStep "Skiping validation for ${OUTPUT}"
   fi
 done
 


### PR DESCRIPTION
Currently, all docker images are validated to have a `node_modules` directory, but the finance-portal-ui is an nginx that serves static files, so the pipeline in the helm repo fails here: https://circleci.com/gh/mojaloop/helm/1319?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

this changes omit the validation on the finance-portal-ui repo.