### PR TITLE
feat: #1908 Audit issue with `event-stream`, Widdershins child depend…

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -130,7 +130,8 @@ excludeList = [
   "taffydb@2.6.2;Contains MIT license on github, but not listed in package.json",
   "buffercursor@0.0.12;No license on github or npm", # has no license on github or npm
   "cycle@1.0.3;Listed as Public-Domain on npm, but no License file in github",
-  "spdx-exceptions@2.2.0;Requires attribution"
+  "spdx-exceptions@2.2.0;Requires attribution",
+  "event-stream@3.3.4;Custom license not conforming to standard formats, but MIT license specified on Github and NPM.org. Issue fixed on v4.x and later, but direct dependencies have not been updated respectively."
 ]
 
 ##


### PR DESCRIPTION
Added event-stream version 3.3.4 to exclude list due to the following issue --> https://github.com/mojaloop/project/issues/1908