### PR TITLE
feat: #1908 Audit issue with `event-stream`, Widdershins child dependency (hotfix)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -131,7 +131,7 @@ excludeList = [
   "buffercursor@0.0.12;No license on github or npm", # has no license on github or npm
   "cycle@1.0.3;Listed as Public-Domain on npm, but no License file in github",
   "spdx-exceptions@2.2.0;Requires attribution",
-  "event-stream@3.3.4;Custom license not conforming to standard formats, but MIT license specified on Github and NPM.org. Issue fixed on v4.x and later, but direct dependencies have not been updated respectively."
+  "map-stream@0.1.0;Custom license not conforming to standard formats, but MIT license specified on Github and NPM.org. Issue fixed on v4.x and later, but direct dependencies have not been updated respectively."
 ]
 
 ##


### PR DESCRIPTION
Added map-stream version 0.1.0 to exclude list due to the following issue --> mojaloop/project#1908
Removed event-stream.

The current error that this change fixes:
Package "map-stream@0.1.0" is licensed under "Custom: https://github.com/dominictarr/event-stream" which is not permitted by the --onlyAllow flag. Exiting.