### PR TITLE
Feature/include bsd 3 clause clear license

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -147,6 +147,7 @@ allowedList = [
   "BSD*",
   "BSD-2-Clause",
   "BSD-3-Clause",
+  "BSD-3-Clause-Clear",
   "CC-BY-3.0",
   "CC-BY-4.0",
   "CC0-1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/license-scanner-scripts",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "description": "",
   "main": "test_xlsx.js",
   "scripts": {


### PR DESCRIPTION
I want to use the npm package github-api which has the license 'BSD-3-Clause-Clear'.
Please suggest if I can use that package?
https://www.npmjs.com/package/github-api

I found the following information about the difference between BSD-3-Clause and BSD-3-Clause-Clear licenses

> Inventions protected by patents can have a software component (or in some cases be completely covered by software). The additional text in the BSD-3-Clause-Clear license makes it explicit that if the software is also covered by a patent, then everybody must request a separate patent license from the patent holder to be able to use the software.

> This is no different from the regular BSD-3-Clause license, although there it is possible to use a defense when you are sued for patent infringement that there could have been an implied patent license.

> The situation is the exact opposite of the patent clause in the Apache 2.0 license. The Apache 2.0 license grants you a patent license in addition to the copyright license, while the BSD-3-Clause-Clear license makes it explicit that there is no such combined license
