### PR TITLE
chore: add axe-core to excludeList

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -131,7 +131,8 @@ excludeList = [
   "buffercursor@0.0.12;No license on github or npm", # has no license on github or npm
   "cycle@1.0.3;Listed as Public-Domain on npm, but no License file in github",
   "spdx-exceptions@2.2.0;Requires attribution",
-  "map-stream@0.1.0;Custom license not conforming to standard formats, but MIT license specified on Github and NPM.org. Issue fixed on v4.x and later, but direct dependencies have not been updated respectively."
+  "map-stream@0.1.0;Custom license not conforming to standard formats, but MIT license specified on Github and NPM.org. Issue fixed on v4.x and later, but direct dependencies have not been updated respectively.",
+  "axe-core@4.4.3;MPL2 License, new files containing no MPL-licensed code are not Modifications, and therefore do not need to be distributed under the terms of the MPL, a Larger Work (as defined in Section 1.7 of the MPL License) by using, compiling, or distributing the non-MPL files together with MPL-licensed files"
 ]
 
 ##


### PR DESCRIPTION
- Added `axe-core` to `excludeList` which is an inner child dependency on `react-scripts` dependency, required for UI projects.
- `axe-core` is licensed under MPL2 - new files containing no MPL-licensed code are not Modifications, and therefore do not need to be distributed under the terms of the MPL, a Larger Work (as defined in Section 1.7 of the MPL License) by using, compiling, or distributing the non-MPL files together with MPL-licensed files. Ref: [Q11 from MPL 2.0 FAQ](https://www.mozilla.org/en-US/MPL/2.0/FAQ/).