### PR TITLE
chore: added blueoak license to allowedList

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -145,6 +145,7 @@ allowedList = [
   "Apache*",
   "Apache-2.0",
   "Apache 2.0",
+  "BlueOak-1.0.0",
   "BSD",
   "BSD*",
   "BSD-2-Clause",


### PR DESCRIPTION
chore: added blueoak license to allowedList

This is a follow-up to DA issue https://github.com/mojaloop/design-authority-project/issues/101.